### PR TITLE
Use top_builddir instead of ROOT

### DIFF
--- a/mcwin32/Makefile.in
+++ b/mcwin32/Makefile.in
@@ -27,7 +27,6 @@
 #
 
 @SET_MAKE@
-ROOT		= @abs_top_builddir@
 
 PACKAGE		= mc
 PKG_BUGREPORT	= @PACKAGE_BUGREPORT@
@@ -163,10 +162,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)
 LW=		$(D_LIB)/$(LP)
 
 D_ETC=		$(D_BIN)/etc

--- a/mcwin32/autoupdater/Makefile.in
+++ b/mcwin32/autoupdater/Makefile.in
@@ -6,7 +6,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -42,10 +41,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libautoupdater
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libautoupdater
 
 # Common flags
 

--- a/mcwin32/libglib/Makefile.in
+++ b/mcwin32/libglib/Makefile.in
@@ -29,7 +29,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -67,10 +66,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libglib
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libglib
 
 # Common flags
 

--- a/mcwin32/libintl/Makefile.in
+++ b/mcwin32/libintl/Makefile.in
@@ -6,7 +6,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -41,10 +40,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libintl
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libintl
 
 # Common flags
 

--- a/mcwin32/libmagic/Makefile.in
+++ b/mcwin32/libmagic/Makefile.in
@@ -6,7 +6,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -42,10 +41,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libmagic
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libmagic
 
 # Common flags
 

--- a/mcwin32/libmagic/Makefile.in.5.29
+++ b/mcwin32/libmagic/Makefile.in.5.29
@@ -6,7 +6,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -42,10 +41,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/objects@TOOLCHAINEXT@/$(BUILD_TYPE)/libmagic
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/objects@TOOLCHAINEXT@/$(BUILD_TYPE)/libmagic
 
 # Common flags
 

--- a/mcwin32/libmbedtls/Makefile.in
+++ b/mcwin32/libmbedtls/Makefile.in
@@ -24,7 +24,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -60,10 +59,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libmbedtls
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libmbedtls
 
 # Common flags
 

--- a/mcwin32/libmbedtls/Makefile.in.2_13_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_13_0
@@ -27,7 +27,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -75,10 +74,10 @@ RMFLAGS=	-f
 
 # Directories
 
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@
-D_INC=		$(ROOT)/include
-D_OBJ=		$(ROOT)/objects@TOOLCHAINEXT@/libmbedtls
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@
+D_INC=		$(top_builddir)/include
+D_OBJ=		$(top_builddir)/objects@TOOLCHAINEXT@/libmbedtls
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@
 
 ############################################################
 

--- a/mcwin32/libmbedtls/Makefile.in.2_16_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_16_0
@@ -24,7 +24,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -60,10 +59,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/objects@TOOLCHAINEXT@/$(BUILD_TYPE)/libmbedtls
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/objects@TOOLCHAINEXT@/$(BUILD_TYPE)/libmbedtls
 
 # Common flags
 

--- a/mcwin32/libregex/Makefile.in
+++ b/mcwin32/libregex/Makefile.in
@@ -6,7 +6,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -39,10 +38,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libregex
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libregex
 
 # Common flags
 

--- a/mcwin32/libssh2/Makefile.in
+++ b/mcwin32/libssh2/Makefile.in
@@ -25,7 +25,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -61,10 +60,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libssh2
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libssh2
 
 # Common flags
 

--- a/mcwin32/libw32/Makefile.in
+++ b/mcwin32/libw32/Makefile.in
@@ -23,7 +23,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -59,10 +58,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libw32
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libw32
 
 # Common flags
 

--- a/mcwin32/libz/Makefile.in
+++ b/mcwin32/libz/Makefile.in
@@ -29,7 +29,6 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions
@@ -65,10 +64,10 @@ endif
 
 # Directories
 
-D_INC=		$(ROOT)/include
-D_BIN=		$(ROOT)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_LIB=		$(ROOT)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
-D_OBJ=		$(ROOT)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libz
+D_INC=		$(top_builddir)/include
+D_BIN=		$(top_builddir)/bin@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_LIB=		$(top_builddir)/lib@TOOLCHAINEXT@/$(BUILD_TYPE)
+D_OBJ=		$(top_builddir)/obj@TOOLCHAINEXT@/$(BUILD_TYPE)/libz
 
 # Common flags
 

--- a/mcwin32/makeconfig.in
+++ b/mcwin32/makeconfig.in
@@ -82,8 +82,8 @@ if ($TOOLCHAIN =~ /^vs/) {
         add_define('HAVE_CONFIG_H');
         add_define('WIN32_WINNT=0x501');
 
-        add_xinclude('$(ROOT)/libw32');         # Extra includes; C and compiler tests.
-        add_xinclude('$(ROOT)/libw32/msvc');    # MSVC specials
+        add_xinclude('$(top_builddir)/libw32');         # Extra includes; C and compiler tests.
+        add_xinclude('$(top_builddir)/libw32/msvc');    # MSVC specials
 
         add_application_library('libw32.lib');
 }
@@ -98,7 +98,7 @@ if ($TOOLCHAIN =~ /^owc/) {
         add_define('HAVE_CONFIG_H');
         add_define('WIN32_WINNT=0x501');
 
-        add_xinclude('$(ROOT)/libw32');         # Extra includes; C and compiler tests.
+        add_xinclude('$(top_builddir)/libw32');         # Extra includes; C and compiler tests.
 
         add_application_library('libw32.lib');
 }

--- a/mcwin32/makelib.in
+++ b/mcwin32/makelib.in
@@ -106,8 +106,8 @@ Configure()
 		add_define('_CRT_SECURE_NO_DEPRECATE');
 		add_define('_CRT_NONSTDC_NO_DEPRECATE');
 
-		add_xinclude('$(ROOT)/libw32'); 	# Extra includes; C and compiler tests.
-		add_xinclude('$(ROOT)/libw32/msvc');	# MSVC specials
+		add_xinclude('$(top_builddir)/libw32'); 	# Extra includes; C and compiler tests.
+		add_xinclude('$(top_builddir)/libw32/msvc');	# MSVC specials
 
 		add_application_library('libw32.lib');
 	}
@@ -122,7 +122,7 @@ Configure()
 		add_define('WIN32_WINNT=0x501');
 		add_define('__STDC_WANT_LIB_EXT1__');
 
-		add_xinclude('$(ROOT)/libw32');
+		add_xinclude('$(top_builddir)/libw32');
 		add_application_library('libw32.lib');
 	}
 
@@ -138,7 +138,7 @@ Configure()
 		add_define('_WIN32_WINNT=0x501');	# Windows SDK
 		add_define('_WIN32_VER=0x501');
 
-		add_xinclude('$(ROOT)/libw32');
+		add_xinclude('$(top_builddir)/libw32');
 		add_application_library('libw32.a');
 
 		if ($TOOLCHAIN =~ /^mingw(64|32)/) {	# newer libraries

--- a/mcwin32/makelib.pl
+++ b/mcwin32/makelib.pl
@@ -82,7 +82,7 @@ my %x_environment   = (
             CXX             => 'g++',
             AR              => 'ar',
             DEFS            => '-DHAVE_CONFIG_H',
-            CFLAGS          => '-fno-strength-reduce -I$(ROOT)/djgpp',
+            CFLAGS          => '-fno-strength-reduce -I$(top_builddir)/djgpp',
             CDEBUG          => '-g',
             CWARN           => '-W -Wall -Wshadow -Wmissing-prototypes',
             },
@@ -2013,7 +2013,7 @@ ExeRealpath($)
         $path =~ s/\.exe//;
 
     } elsif ($path =~ /^\.[\/\\]/) {        # ./xxxx; assume a generated artifact
-        $path =~ s/^\./\$(ROOT)/;
+        $path =~ s/^\./\$(top_builddir)/;
 
     } else {
         print "warning: unable to resolve path <${path}>\n";
@@ -2069,7 +2069,7 @@ LoadContrib($$$$$)      # (type, version, name, dir, refIncludes)
             } elsif ('inc' eq $parts[0]) {
                 $val = "${basepath}/".$parts[1]
                     if ($val !~ /^\//);
-                push @$refIncludes, '$(ROOT)/'.$val;
+                push @$refIncludes, '$(top_builddir)/'.$val;
                 print "\tinc: $val\n";
 
             } elsif ('lbl' eq $key) {
@@ -2256,7 +2256,7 @@ CheckCompiler($$)       # (type, env)
 
         foreach my $inc (@xincludes) {
             if ($inc) {
-                $inc =~ s/\$\(ROOT\)/${CWD}/;
+                $inc =~ s/\$\(top_builddir\)/${CWD}/;
                 $inc = realpath($inc)
                     if (-d $inc);
 


### PR DESCRIPTION
Building with MSYS2 was failing due to the command line for linking glib DLL exceeding the sh.exe limit of 8192 bytes. When sh.exe from MSYS2 was present in PATH, gmake would use it and run a truncated command.

Using relative filenames shortens that command line to about 5k regardless of the source directory location.

The use of absolute paths to any files in the build directory should be strongly discouraged, as the build should not keep memory of the location where it was built.

Replace ROOT with top_builddir everywhere. The ROOT variable was not named correctly, the standard name is abs_top_builddir and it remains available in case it's ever needed.