### PR TITLE
Don't redirect output to /dev/null or NUL in makefiles

### DIFF
--- a/mcwin32/Makefile.in
+++ b/mcwin32/Makefile.in
@@ -115,7 +115,7 @@ XCLEAN=		$(D_BIN)/*.map
 
 BUSYBOX=	@BUSYBOX@
 ifeq ($(BUSYBOX),busybox)
-BUSYBOX=	$(shell which busybox 2>/dev/null)
+BUSYBOX=	$(shell which busybox)
 endif
 
 ifeq ("$(BUILD_TYPE)","")	#default
@@ -849,10 +849,10 @@ package:	packageinfo
 .PHONY:		clean
 clean:
 		@echo $(BUILD_TYPE) clean
-		-$(RM) $(RMFLAGS) $(TARGETS) $(LIBRARIES) $(CLEAN) $(XCLEAN) >nul 2>&1
-		-$(RM) $(RMFLAGS) $(OBJS) $(MC_RES) $(subst $(O),.mbr,$(OBJS) $(MC_RES)) >nul 2>&1
-		-$(RM) $(RMFLAGS) $(MC_LIBMC) $(subst $(O),.mbr,$(MC_LIBMC)) $(LW)mcutil$(A) >nul 2>&1
-		-$(RM) $(RMFLAGS) $(MC_LIBVFS) $(subst $(O),.mbr,$(MC_LIBVFS)) $(LW)mcvfs$(A) >nul 2>&1
+		-$(RM) $(RMFLAGS) $(TARGETS) $(LIBRARIES) $(CLEAN) $(XCLEAN)
+		-$(RM) $(RMFLAGS) $(OBJS) $(MC_RES) $(subst $(O),.mbr,$(OBJS) $(MC_RES))
+		-$(RM) $(RMFLAGS) $(MC_LIBMC) $(subst $(O),.mbr,$(MC_LIBMC)) $(LW)mcutil$(A)
+		-$(RM) $(RMFLAGS) $(MC_LIBVFS) $(subst $(O),.mbr,$(MC_LIBVFS)) $(LW)mcvfs$(A)
 		$(MAKE) -C libglib clean
 		$(MAKE) -C libintl clean
 		$(MAKE) -C libmbedtls clean
@@ -862,16 +862,16 @@ clean:
 		$(MAKE) -C libz clean
 		$(MAKE) -C libw32 clean
 		$(MAKE) -C autoupdater clean
-		-$(RM) $(MSGOBJS) $(MSGDIRS) >nul 2>&1
-		-$(RM) $(CONFIGURATION) >nul 2>&1
-		-$(RM) $(CONFIGURATION_WIN32) >nul 2>&1
-		-$(RM) $(DIRECTORIES) >nul 2>&1
-		-$(RMDIR) $(call reverse, $(dir $(DIRECTORIES)) $(BASEMSGDIRS) $(dir $(MSGDIRS)))) >nul 2>&1
-		-$(RMDIR) $(D_OBJ) $(D_LIB) $(D_BIN) $(D_ETC) >nul 2>&1
+		-$(RM) $(MSGOBJS) $(MSGDIRS)
+		-$(RM) $(CONFIGURATION)
+		-$(RM) $(CONFIGURATION_WIN32)
+		-$(RM) $(DIRECTORIES)
+		-$(RMDIR) $(call reverse, $(dir $(DIRECTORIES)) $(BASEMSGDIRS) $(dir $(MSGDIRS))))
+		-$(RMDIR) $(D_OBJ) $(D_LIB) $(D_BIN) $(D_ETC)
 
 .PHONY:		vclean
 vclean:		clean
-		-$(RM) $(IMPORT) >nul 2>&1
+		-$(RM) $(IMPORT)
 
 
 #########################################################################################
@@ -920,13 +920,13 @@ endif
 
 .PHONY:			new_buildnumber
 new_buildnumber:
-		-@chmod +w BUILDNUMBER >nul 2>&1
+		-@chmod +w BUILDNUMBER
 		@echo incrementing build number ...
 		-@$(BUSYBOX) sh -c "\
 			if [ ! -f BUILDNUMBER ]; then echo 1 >BUILDNUMBER; fi;\
 			echo $$(($$(cat BUILDNUMBER) + 1)) >BUILDNUMBER;\
 			"
-		-@chmod -w BUILDNUMBER >/dev/null 2>&1
+		-@chmod -w BUILDNUMBER
 
 $(D_OBJ)/%.res:		%.rc
 		$(RC) -fo $@ $<

--- a/mcwin32/autoupdater/Makefile.in
+++ b/mcwin32/autoupdater/Makefile.in
@@ -215,7 +215,7 @@ installinc:		include/.created
 		@echo "do not delete, managed directory" > $@
 
 clean:
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(OBJS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(OBJS) $(CLEAN) $(XCLEAN)
 
 $(D_OBJ)/%$(O):		%.cpp
 		$(CC) $(CXXFLAGS) -o $@ -c $<

--- a/mcwin32/libglib/Makefile.in
+++ b/mcwin32/libglib/Makefile.in
@@ -359,7 +359,7 @@ debug:
 $(GLIBLIB):		CLOCAL += -I. -I$(GLIBSRC)
 $(GLIBLIB):		CEXTRA += -DGLIB_COMPILATION -DGLIB_STATIC_COMPILATION -DPCRE_STATIC
 $(GLIBLIB):		$(GLIBLIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -373,7 +373,7 @@ $(GLIBDLL):		$(GLIBDLLOBJS)
 
 $(GMODULELIB):		CLOCAL += -I. -I$(GMODULESRC) -I$(GLIBSRC)
 $(GMODULELIB):		$(GMODULELIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -490,11 +490,11 @@ installheaders:		Makefile ../include/.created \
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(subst /,\,$(GLIBDLL) $(GLIBDLLOBJS) >nul 2>&1)
-		-@$(LIBTOOL) --mode=clean $(RM) $(subst /,\,$(GMODULEDLL) $(GMODULEDLLOBJS) >nul 2>&1)
-		-@$(RM) $(subst /,\,$(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >nul 2>&1)
-		-@$(RM) $(subst /,\,$(GLIBLIBOBJS) >nul 2>&1)
-		-@$(RM) $(subst /,\,$(GMODULELIBOBJS) >nul 2>&1)
+		-@$(LIBTOOL) --mode=clean $(RM) $(subst /,\,$(GLIBDLL) $(GLIBDLLOBJS))
+		-@$(LIBTOOL) --mode=clean $(RM) $(subst /,\,$(GMODULEDLL) $(GMODULEDLLOBJS))
+		-@$(RM) $(subst /,\,$(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN))
+		-@$(RM) $(subst /,\,$(GLIBLIBOBJS))
+		-@$(RM) $(subst /,\,$(GMODULELIBOBJS))
 
 
 ############################################################

--- a/mcwin32/libintl/Makefile.in
+++ b/mcwin32/libintl/Makefile.in
@@ -121,7 +121,7 @@ debug:
 
 $(INTLLIB):		CEXTRA += -I$(INTLSRC) -DLIBINTL_STATIC -D__LIBINTL_BUILD -D_WIN32
 $(INTLLIB):		$(LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $(subst /,\,$^)
 		$(RANLIB) $@
 
@@ -146,9 +146,9 @@ installinc:		../include/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(INTLDLL) $(DLLOBJS) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
-		-@$(RM) $(LIBOBJS) >/dev/null 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(INTLDLL) $(DLLOBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(LIBOBJS)
 
 $(D_OBJ)/%$(O):		%.c
 		$(CC) $(CFLAGS) -o $@ -c $<

--- a/mcwin32/libmagic/Makefile.in
+++ b/mcwin32/libmagic/Makefile.in
@@ -167,7 +167,7 @@ debug:
 
 $(MAGICLIB):		CEXTRA += -D__LIBMAGIC_BUILD -DLIBMAGIC_STATIC -DBUILD_AS_WINDOWS_STATIC_LIBARAY
 $(MAGICLIB):		$(D_OBJ)/.created $(LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $(LIBOBJS)
 		$(RANLIB) $@
 
@@ -211,9 +211,9 @@ installinc:		../include/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(MAGICDLL) $(OBJS) >nul 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >nul 2>&1
-		-@$(RM) $(LIBOBJS) $(UTILOBJS) >nul 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(MAGICDLL) $(OBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(LIBOBJS) $(UTILOBJS)
 
 $(D_OBJ)/%$(O):		%$(C)
 		$(CC) $(CFLAGS) -D_CRT_SECURE_NO_DEPRECATE -o $@ -c $<

--- a/mcwin32/libmbedtls/Makefile.in
+++ b/mcwin32/libmbedtls/Makefile.in
@@ -239,7 +239,7 @@ CEXTRA		+= -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 #######
 $(MBEDCRYPTOLIB):	CEXTRA += -DLIBMBED_STATIC -DLIBMBEDCRYPTO_SOURCE
 $(MBEDCRYPTOLIB):	$(CRYPTO_LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -254,7 +254,7 @@ $(MBEDCRYPTODLL):	$(CRYPTO_DLLOBJS)
 #######
 $(MBEDX509LIB):		CEXTRA += -DLIBMBED_STATIC -DLIBMBEDX509_SOURCE -DLIBMBEDX509
 $(MBEDX509LIB):		$(X509_LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -269,7 +269,7 @@ $(MBEDX509DLL):		$(X509_DLLOBJS)
 #######
 $(MBEDTLSLIB):		CEXTRA += -DLIBMBED_STATIC -DLIBMBEDTLS_SOURCE
 $(MBEDTLSLIB):		$(TLS_LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -310,10 +310,10 @@ installinc:		../include/.created ../include/mbedtls/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(DLLS) $(DLLOBJS) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
-		-@$(RM) $(LIBOBJS) >/dev/null 2>&1
-		-@$(RM) ../include/mbedtls/* >/dev/null 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(DLLS) $(DLLOBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(LIBOBJS)
+		-@$(RM) ../include/mbedtls/*
 
 $(D_OBJ)/%$(O):		%.c
 		$(CC) $(CFLAGS) -o $@ -c $<

--- a/mcwin32/libregex/Makefile.in
+++ b/mcwin32/libregex/Makefile.in
@@ -112,7 +112,8 @@ installinc:		../include/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(LIBS) $(OBJS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(LIBS) $(OBJS) $(CLEAN) $(XCLEAN)
+
 
 $(D_OBJ)/%$(O):		%$(C)
 		$(CC) $(CFLAGS) -D_CRT_SECURE_NO_DEPRECATE -o $@ -c $<

--- a/mcwin32/libssh2/Makefile.in
+++ b/mcwin32/libssh2/Makefile.in
@@ -183,7 +183,7 @@ CEXTRA		+= -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 
 $(SSH2LIB):		CEXTRA += -DLIBSSH2_STATIC
 $(SSH2LIB):		$(LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -217,10 +217,10 @@ installinc:		../include/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(DLLS) $(DLLOBJS) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
-		-@$(RM) $(LIBOBJS) >/dev/null 2>&1
-		-@$(RM) ../include/libssh2/*.h >/dev/null 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(DLLS) $(DLLOBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(LIBOBJS)
+		-@$(RM) ../include/libssh2/*.h
 
 $(D_OBJ)/%$(O):		%.c
 		$(CC) $(CFLAGS) -o $@ -c $<

--- a/mcwin32/libw32/Makefile.in
+++ b/mcwin32/libw32/Makefile.in
@@ -239,9 +239,9 @@ $(D_OBJ)/.created:
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(W32DLL) $(DLLOBJS) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(W32LIB) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(LIBOBJS) >/dev/null 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(W32DLL) $(DLLOBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(W32LIB) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(RMFLAGS) $(LIBOBJS)
 
 $(D_OBJ)/%$(O):		%.c
 		$(CC) $(CFLAGS) -o $@ -c $<

--- a/mcwin32/libz/Makefile.in
+++ b/mcwin32/libz/Makefile.in
@@ -178,7 +178,7 @@ CEXTRA	+=	-I$(ZSRC) -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 
 $(ZLIB):		CEXTRA += -DZLIB_STATIC
 $(ZLIB):		$(LIBOBJS)
-		$(RM) $(RMFLAGS) $@ >/dev/null 2>&1
+		$(RM) $(RMFLAGS) $@
 		$(AR) $(ARFLAGS) $@ $^
 		$(RANLIB) $@
 
@@ -215,9 +215,9 @@ installinc:		../include/.created
 
 clean:
 		@echo $(BUILD_TYPE) clean
-		-@$(LIBTOOL) --mode=clean $(RM) $(ZDLL) $(DLLOBJS) >/dev/null 2>&1
-		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN) >/dev/null 2>&1
-		-@$(RM) $(LIBOBJS) >/dev/null 2>&1
+		-@$(LIBTOOL) --mode=clean $(RM) $(ZDLL) $(DLLOBJS)
+		-@$(RM) $(RMFLAGS) $(BAK) $(TSKS) $(INSTALLED) $(LIBS) $(CLEAN) $(XCLEAN)
+		-@$(RM) $(LIBOBJS)
 
 $(D_OBJ)/%$(O):		%.c
 		$(CC) $(CFLAGS) -o $@ -c $<


### PR DESCRIPTION
Hiding output makes it harder to troubleshoot problems with the build system.

When `sh.exe` is present in PATH, files named NUL are created in the source directories. They are problematic to remove.