### PR TITLE
Set ROOT to top_builddir

### DIFF
--- a/mcwin32/Makefile.in
+++ b/mcwin32/Makefile.in
@@ -27,7 +27,7 @@
 #
 
 @SET_MAKE@
-ROOT		= @abs_top_builddir@
+ROOT		= @top_builddir@
 
 PACKAGE		= mc
 PKG_BUGREPORT	= @PACKAGE_BUGREPORT@

--- a/mcwin32/autoupdater/Makefile.in
+++ b/mcwin32/autoupdater/Makefile.in
@@ -6,7 +6,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libglib/Makefile.in
+++ b/mcwin32/libglib/Makefile.in
@@ -29,7 +29,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libintl/Makefile.in
+++ b/mcwin32/libintl/Makefile.in
@@ -6,7 +6,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libmagic/Makefile.in
+++ b/mcwin32/libmagic/Makefile.in
@@ -6,7 +6,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libmagic/Makefile.in.5.29
+++ b/mcwin32/libmagic/Makefile.in.5.29
@@ -6,7 +6,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libmbedtls/Makefile.in
+++ b/mcwin32/libmbedtls/Makefile.in
@@ -24,7 +24,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libmbedtls/Makefile.in.2_13_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_13_0
@@ -27,7 +27,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libmbedtls/Makefile.in.2_16_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_16_0
@@ -24,7 +24,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libregex/Makefile.in
+++ b/mcwin32/libregex/Makefile.in
@@ -6,7 +6,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libssh2/Makefile.in
+++ b/mcwin32/libssh2/Makefile.in
@@ -25,7 +25,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libw32/Makefile.in
+++ b/mcwin32/libw32/Makefile.in
@@ -23,7 +23,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions

--- a/mcwin32/libz/Makefile.in
+++ b/mcwin32/libz/Makefile.in
@@ -29,7 +29,7 @@
 #
 
 @SET_MAKE@
-ROOT=		@abs_top_builddir@
+ROOT=		@top_builddir@
 top_builddir=	@top_builddir@
 
 # File extensions


### PR DESCRIPTION
Building with MSYS2 was failing due to the command line for linking glib DLL exceeding the sh.exe limit of 8192 bytes. When sh.exe from MSYS2 was present in PATH, gmake would use it and run a truncated command.

Using relative filenames shortens that command line to about 5k regardless of the source directory location.