### PR TITLE
Set MAKESHELL to cmd.exe explicitly in all makefiles

### DIFF
--- a/mcwin32/Makefile.in
+++ b/mcwin32/Makefile.in
@@ -27,6 +27,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL	= cmd.exe
 ROOT		= @abs_top_builddir@
 
 PACKAGE		= mc

--- a/mcwin32/autoupdater/Makefile.in
+++ b/mcwin32/autoupdater/Makefile.in
@@ -6,6 +6,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libglib/Makefile.in
+++ b/mcwin32/libglib/Makefile.in
@@ -29,6 +29,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libintl/Makefile.in
+++ b/mcwin32/libintl/Makefile.in
@@ -6,6 +6,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libmagic/Makefile.in
+++ b/mcwin32/libmagic/Makefile.in
@@ -6,6 +6,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libmagic/Makefile.in.5.29
+++ b/mcwin32/libmagic/Makefile.in.5.29
@@ -6,6 +6,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libmbedtls/Makefile.in
+++ b/mcwin32/libmbedtls/Makefile.in
@@ -24,6 +24,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libmbedtls/Makefile.in.2_13_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_13_0
@@ -27,6 +27,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libmbedtls/Makefile.in.2_16_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_16_0
@@ -24,6 +24,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libregex/Makefile.in
+++ b/mcwin32/libregex/Makefile.in
@@ -6,6 +6,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libssh2/Makefile.in
+++ b/mcwin32/libssh2/Makefile.in
@@ -25,6 +25,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libw32/Makefile.in
+++ b/mcwin32/libw32/Makefile.in
@@ -23,6 +23,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 

--- a/mcwin32/libz/Makefile.in
+++ b/mcwin32/libz/Makefile.in
@@ -29,6 +29,7 @@
 #
 
 @SET_MAKE@
+MAKESHELL=	cmd.exe
 ROOT=		@abs_top_builddir@
 top_builddir=	@top_builddir@
 


### PR DESCRIPTION
GNU Make exhibits subtle differences in behavior dependent on whether `sh.exe` is in PATH. Setting `MAKESHELL=cmd.exe` ensures consistent behavior.