### PR TITLE
Use perl mkdir implementation that supports back and forward slashes

### DIFF
--- a/mcwin32/Makefile.in
+++ b/mcwin32/Makefile.in
@@ -789,7 +789,7 @@ directories:			$(DIRECTORIES)
 artifacts:			buildinfo BUILDNUMBER
 
 %/.created:
-		-@$(PERL) ./support/mkdir_p.pl $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "++ do not delete, midnight commander managed content ++" > $@
 
 targets:			$(LIBRARIES) $(TARGETS)

--- a/mcwin32/autoupdater/Makefile.in
+++ b/mcwin32/autoupdater/Makefile.in
@@ -220,7 +220,7 @@ installinc:		include/.created
 		-cp magic.mgc $(D_BIN)
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libglib/Makefile.in
+++ b/mcwin32/libglib/Makefile.in
@@ -494,7 +494,7 @@ installheaders:		Makefile ../include/.created \
 		@$(CP) $(GMODULESRC)/gmodule.h			../include/glib-2.0
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libintl/Makefile.in
+++ b/mcwin32/libintl/Makefile.in
@@ -150,7 +150,7 @@ installinc:		../include/.created
 		-cp $(INTLSRC)/libintl.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libmagic/Makefile.in
+++ b/mcwin32/libmagic/Makefile.in
@@ -197,7 +197,7 @@ $(MAGICDB):		magic.mgc
 magic.mgc:		MSRC=$(wildcard $(MAGDIR)/Magdir/*)
 magic.mgc:		$(MSRC) Makefile
 		@$(RM) -fr magic
-		-@mkdir magic
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl magic
 		@cp $(MSRC) magic
 		$(MAGICUTIL) -C -m magic
 		@$(RM) -fr magic
@@ -215,7 +215,7 @@ installinc:		../include/.created
 		@cp $(MAGICSRC)/magic.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libmagic/Makefile.in.5.29
+++ b/mcwin32/libmagic/Makefile.in.5.29
@@ -174,7 +174,7 @@ $(MAGICDB):		magic.mgc
 magic.mgc:		MSRC=$(wildcard $(MAGDIR)/Magdir/*)
 magic.mgc:		$(MSRC) Makefile
 		@$(RM) -fr magic
-		-@mkdir magic
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl magic
 		@cp $(MSRC) magic
 		$(MAGICUTIL) -C -m magic
 		@$(RM) -fr magic
@@ -192,7 +192,7 @@ installinc:		../include/.created
 		@cp $(MAGICSRC)/magic.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libmbedtls/Makefile.in
+++ b/mcwin32/libmbedtls/Makefile.in
@@ -314,7 +314,7 @@ installinc:		../include/.created ../include/mbedtls/.created
 		-cp ./win32/*.h ../include/mbedtls
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libmbedtls/Makefile.in.2_13_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_13_0
@@ -268,7 +268,7 @@ installinc:		../include/.created ../include/mbedtls/.created
 		-cp ./win32/*.h ../include/mbedtls
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libmbedtls/Makefile.in.2_16_0
+++ b/mcwin32/libmbedtls/Makefile.in.2_16_0
@@ -284,7 +284,7 @@ installinc:		../include/.created ../include/mbedtls/.created
 		-cp ./win32/*.h ../include/mbedtls
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libregex/Makefile.in
+++ b/mcwin32/libregex/Makefile.in
@@ -116,7 +116,7 @@ installinc:		../include/.created
 		-cp regex.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" >$@
 
 clean:

--- a/mcwin32/libssh2/Makefile.in
+++ b/mcwin32/libssh2/Makefile.in
@@ -221,7 +221,7 @@ installinc:		../include/.created
 		-cp libssh2_helper.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:

--- a/mcwin32/libw32/Makefile.in
+++ b/mcwin32/libw32/Makefile.in
@@ -243,7 +243,7 @@ $(W32DLL):		$(DLLOBJS)
 			-rpath $(D_LIB) -bindir $(D_BIN) $(DLLDEF) $^ $(LDLIBS)
 
 $(D_OBJ)/.created:
-		-@mkdir $(D_OBJ)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(D_OBJ)
 		@echo "do not create" > $@
 
 clean:

--- a/mcwin32/libz/Makefile.in
+++ b/mcwin32/libz/Makefile.in
@@ -220,7 +220,7 @@ installinc:		../include/.created
 		-cp $(ZSRC)/zconf.h ../include
 
 %/.created:
-		-@mkdir $(@D)
+		@$(PERL) $(top_builddir)/support/mkdir_p.pl $(@D)
 		@echo "do not delete, managed directory" > $@
 
 clean:


### PR DESCRIPTION
It's more predictable than whatever the user can have in PATH. Also, it can create hierarchies of subdirectories and doesn't fail if the directory exists already.

Don't ignore failures to create a directory.